### PR TITLE
Remove Howdy from admin bar

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -138,6 +138,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'remove-admin-bar-howdy' => [
+				'label' => esc_html__( 'Remove Howdy from admin bar', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 			'remove-dashboard-widgets' => [
 				'label' => esc_html__( 'Remove some default dashboard widgets (useless for clients)', 'wp-tweaks' ),
 				'type' => 'checkbox',

--- a/inc/tweaks/remove-admin-bar-howdy.php
+++ b/inc/tweaks/remove-admin-bar-howdy.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Remove "Howdy" from admin bar
+ *
+ * @package wp-tweaks
+ */
+
+add_action( 'admin_bar_menu', 'wp_tweaks_remove_howdy', 11 );
+ 
+function wp_tweaks_remove_howdy( $wp_admin_bar ) {
+    $my_account = $wp_admin_bar->get_node('my-account');
+    $newtitle = str_replace( 'Howdy, ', '', $my_account->title );
+    $wp_admin_bar->add_node( array(
+      'id' => 'my-account',
+      'title' => $newtitle,
+    ) );
+}

--- a/inc/tweaks/remove-admin-bar-howdy.php
+++ b/inc/tweaks/remove-admin-bar-howdy.php
@@ -5,13 +5,13 @@
  * @package wp-tweaks
  */
 
-add_action( 'admin_bar_menu', 'wp_tweaks_remove_howdy', 11 );
- 
-function wp_tweaks_remove_howdy( $wp_admin_bar ) {
-    $my_account = $wp_admin_bar->get_node('my-account');
-    $newtitle = str_replace( 'Howdy, ', '', $my_account->title );
-    $wp_admin_bar->add_node( array(
-      'id' => 'my-account',
-      'title' => $newtitle,
-    ) );
+add_action( 'admin_bar_menu', 'wp_tweaks_remove_howdy', 20 );
+function wp_tweaks_remove_howdy ( $wp_admin_bar ) {
+	$current_user = wp_get_current_user();
+	$avatar = get_avatar( $current_user->ID, 28 );
+
+	$wp_admin_bar->add_node( [
+		'id' => 'my-account',
+		'title' => $current_user->display_name . $avatar
+	] );
 }


### PR DESCRIPTION
Removes Howdy text from admin bar. For issue https://github.com/luizbills/wp-tweaks/issues/3