### PR TITLE
Show second editor row by default

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -168,6 +168,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'second-editor-row' => [
+				'label' => esc_html__( 'Show second editor row by default', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 		];
 	}
 

--- a/inc/tweaks/second-editor-row.php
+++ b/inc/tweaks/second-editor-row.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Enable second row on editor by default
+ *
+ * @package wp-tweaks
+ */
+
+add_filter( 'tiny_mce_before_init', 'wp_tweaks_second_editor_row' );
+
+function wp_tweaks_second_editor_row ( $tinymce ) {
+    $tinymce[ 'wordpress_adv_hidden' ] = FALSE;
+    return $tinymce;
+}


### PR DESCRIPTION
I think this should also be in the tweaks, but should it be enabled by default?