### PR TITLE
Override user_can_richedit functionality

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -168,6 +168,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'editor-rich-edit' => [
+				'label' => esc_html__( 'Overrides the function user_can_richedit and only checks the user preferences instead of doing UA sniffing.', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 		];
 	}
 

--- a/inc/tweaks/editor-rich-edit.php
+++ b/inc/tweaks/editor-rich-edit.php
@@ -6,16 +6,9 @@
  * @package wp-tweaks
  */
 
-add_filter('user_can_richedit', 'wp_tweaks_user_can_richedit_custom');
-
-function wp_tweaks_user_can_richedit_custom() {
-  global $wp_rich_edit;
- 
-  if (get_user_option('rich_editing') == 'true' || !is_user_logged_in()) {
-    $wp_rich_edit = true;
-    return true;
-  }
- 
-  $wp_rich_edit = false;
-  return false;
+add_filter( 'user_can_richedit', 'wp_tweaks_user_can_richedit_custom' );
+function wp_tweaks_user_can_richedit_custom ( $value ) {
+	global $wp_rich_edit;
+	$wp_rich_edit = is_user_logged_in() && 'true' === get_user_option( 'rich_editing' );
+	return $wp_rich_edit;
 }

--- a/inc/tweaks/editor-rich-edit.php
+++ b/inc/tweaks/editor-rich-edit.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Overrides the function user_can_richedit and only checks the
+ * user preferences instead of doing UA sniffing.
+ * 
+ * @package wp-tweaks
+ */
+
+add_filter('user_can_richedit', 'wp_tweaks_user_can_richedit_custom');
+
+function wp_tweaks_user_can_richedit_custom() {
+  global $wp_rich_edit;
+ 
+  if (get_user_option('rich_editing') == 'true' || !is_user_logged_in()) {
+    $wp_rich_edit = true;
+    return true;
+  }
+ 
+  $wp_rich_edit = false;
+  return false;
+}


### PR DESCRIPTION
This overrides the function user_can_richedit and only checks the user preferences instead of doing UA sniffing. WordPress normally determines with browser User-Agent if rich editing can be enabled, however on some cases (for example when behind load balancer) UA might be missing, so this is a safer option for the functionality.