### PR TITLE
Remove image links by default

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -168,6 +168,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'remove-image-link' => [
+				'label' => esc_html__( 'Set image links to "None" by default.', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 		];
 	}
 

--- a/inc/tweaks/remove-image-link.php
+++ b/inc/tweaks/remove-image-link.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ *  Force default setting for image link to "none"
+ *
+ * @package wp-tweaks
+ */
+
+add_action('admin_init', 'wp_tweaks_default_image_link_to_none', 10);
+
+function wp_tweaks_default_image_link_to_none() {
+  if ( get_option( 'image_default_link_type' ) !== 'none' ) {
+    update_option('image_default_link_type', 'none');
+  }
+}


### PR DESCRIPTION
By default WordPress should keep the last setting you use when uploading an image, but it does not always work. IMO the default link setting should be "None", rarely direct image links are needed.. 