### PR TITLE
Remove update nags from non-admins

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -168,6 +168,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'remove-update-notifications-from-non-admins' => [
+				'label' => esc_html__( 'Remove update notifications from non-admins.', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 		];
 	}
 

--- a/inc/tweaks/remove-update-notifications-from-non-admins.php
+++ b/inc/tweaks/remove-update-notifications-from-non-admins.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Remove update notifications from non-admins
+ *
+ * @package wp-tweaks
+ */
+
+add_action( 'admin_head', 'wp_tweaks_remove_update_nags_for_non_admins', 1 );
+
+function wp_tweaks_remove_update_nags_for_non_admins() {
+  if (!current_user_can('update_core')) {
+    remove_action( 'admin_notices', 'update_nag', 3 );
+  }
+}


### PR DESCRIPTION
Update notifications for non-admins are confusing, and they have no way to actually update anything. So I think they should be hidden from the beginning.