### PR TITLE
Add Schema markup to posts navigations

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -168,6 +168,12 @@ class WP_Tweaks_Settings {
 				'default' => 'on',
 				'after' => esc_html__( 'Enable', 'wp-tweaks' )
 			],
+			'posts-navigation-schema' => [
+				'label' => esc_html__( 'Add Schema markup to posts navigations.', 'wp-tweaks' ),
+				'type' => 'checkbox',
+				'default' => 'on',
+				'after' => esc_html__( 'Enable', 'wp-tweaks' )
+			],
 		];
 	}
 

--- a/inc/tweaks/posts-navigation-schema.php
+++ b/inc/tweaks/posts-navigation-schema.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Add Schema markup to posts navigations
+ *
+ * @package wp-tweaks
+ */
+
+add_filter( 'next_posts_link_attributes', 'wp_tweaks_next_posts_attributes' );
+
+function wp_tweaks_next_posts_attributes( $attr ) {
+  return $attr . ' itemprop="relatedLink/pagination" ';
+}


### PR DESCRIPTION
Posts navigation should have the schema markup for related pages, there is no harm for having it. Please see this [SO post](https://stackoverflow.com/questions/12382085/is-there-a-pagination-links-microdata-entry/12401406) for more info.