### PR TITLE
reintroduce 'unsafe-eval' in CSP header

### DIFF
--- a/includes/tweaks/security-headers.php
+++ b/includes/tweaks/security-headers.php
@@ -15,7 +15,7 @@ function wp_tweaks_security_headers ( $headers ) {
 			'strict-transport-security' => 'max-age=31536000; includeSubDomains; preload',
 			'x-content-type-options'    => 'nosniff',
 			'x-xss-protection'          => '1; mode=block',
-			'content-security-policy'   => "default-src https:; font-src https: data:; img-src https: data:; script-src https: 'unsafe-inline'; style-src https: 'unsafe-inline'",
+			'content-security-policy'   => "default-src https:; font-src https: data:; img-src https: data:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'",
 			'x-frame-options'           => 'sameorigin',
 			'referrer-policy'           => 'strict-origin-when-cross-origin',
 			'permissions-policy'        => 'geolocation=(), microphone=(), camera=()'


### PR DESCRIPTION
Some wordpress blocks are calling "Function()" and "eval()"